### PR TITLE
Two modifications.

### DIFF
--- a/Samples/SNS/FSampleSNS.dfm
+++ b/Samples/SNS/FSampleSNS.dfm
@@ -13,7 +13,7 @@ object Form1: TForm1
   Font.Style = []
   Position = poScreenCenter
   OnCreate = FormCreate
-  PixelsPerInch = 96
+  OnDestroy = FormDestroy
   TextHeight = 13
   object pnlTop: TPanel
     Left = 0

--- a/Samples/SNS/FSampleSNS.pas
+++ b/Samples/SNS/FSampleSNS.pas
@@ -119,6 +119,7 @@ type
     procedure btnConfirmSubscriptionClick(Sender: TObject);
     procedure btnCreateSMSSandboxPhoneNumberClick(Sender: TObject);
     procedure btnDeleteSMSSandBoxPhoneNumberClick(Sender: TObject);
+    procedure FormDestroy(Sender: TObject);
   private
     FSNSFacade: IAWS4DSNSFacade;
 
@@ -283,6 +284,11 @@ end;
 procedure TForm1.FormCreate(Sender: TObject);
 begin
   LoadConfig;
+end;
+
+procedure TForm1.FormDestroy(Sender: TObject);
+begin
+  SaveConfig;
 end;
 
 function TForm1.GetIniFile: TIniFile;

--- a/Source/SNS/AWS4D.SNS.Service.pas
+++ b/Source/SNS/AWS4D.SNS.Service.pas
@@ -410,9 +410,9 @@ begin
   while Request.Attributes.HasNext do
   begin
     Inc(LCount);
-    LRestRequest.Params.QueryAddOrSet(Format('MessageAttributes.%s.Name', [LCount.ToString]),
+    LRestRequest.Params.QueryAddOrSet(Format('Attributes.entry.%s.Name', [LCount.ToString]),
               Request.Attributes.Current.Key);
-    LRestRequest.Params.QueryAddOrSet(Format('MessageAttributes.%s.Value', [LCount.ToString]),
+    LRestRequest.Params.QueryAddOrSet(Format('Attributes.entry.%s.Value', [LCount.ToString]),
               Request.Attributes.Current.Value);
   end;
 


### PR DESCRIPTION
1- SaveConfig has been added in the FormDestroy method of the main form in project "SampleSNS.dpr" otherwise it won't load the config next time.

2- Message attributes format has been changed in unit "AWS4D.SNS.Service" based on online documentation, the current implementation gets error 400 bad request, have a look at [Updated postman collection](https://www.postman.com/api-evangelist/workspace/amazon-web-services-aws/request/35240-fb4c69ef-d88e-431b-bb92-a1dd0d0c8c08)